### PR TITLE
Fix missing semicolon and added yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor/
 /nbproject/
+/*.yml
+

--- a/src/Aduanizer/Map/MapFactory.php
+++ b/src/Aduanizer/Map/MapFactory.php
@@ -92,7 +92,7 @@ class MapFactory
         } elseif (isset($params['sequence'])) {
             $idGeneration = new IdGeneration('sequence');
         } else {
-            $idGeneration = new IdGeneration($this->defaults['idGeneration'])
+            $idGeneration = new IdGeneration($this->defaults['idGeneration']);
         }
         $table->setIdGeneration($idGeneration);
 


### PR DESCRIPTION
A missing semicolon in src/Aduanizer/Map/MapFactory.php was generating a syntax error.